### PR TITLE
Fix big writes

### DIFF
--- a/py9b/link/ble.py
+++ b/py9b/link/ble.py
@@ -98,15 +98,15 @@ class BLELink(BaseLink):
     def write(self, data):
         if self.dump:
             print(">", hexlify(data).upper())
-            size = len(data)
-            ofs = 0
-            while size:
-                chunk_sz = min(size, _write_chunk_size)
-                self._dev.char_write_handle(
-                    self._wr_handle, bytearray(data[ofs : ofs + chunk_sz])
-                )
-                ofs += chunk_sz
-                size -= chunk_sz
+        size = len(data)
+        ofs = 0
+        while size:
+            chunk_sz = min(size, _write_chunk_size)
+            self._dev.char_write_handle(
+                self._wr_handle, bytearray(data[ofs : ofs + chunk_sz])
+            )
+            ofs += chunk_sz
+            size -= chunk_sz
 
 
 __all__ = ["BLELink"]


### PR DESCRIPTION
This should fix transmission of packets bigger than 20 bytes over bleak link.

Also a quick fix for seemingly broken writes on "legacy" BLE link implementation.

Untested.